### PR TITLE
feat: render only the deepest source defined

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+github: gregberge

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "portal",
     "teleport"
   ],
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/gregberge"
+  },
   "main": "dist/react-teleporter.cjs.js",
   "module": "dist/react-teleporter.es.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,10 @@ export function createTeleporter() {
   function Source({ children }) {
     const [element, setElement] = React.useState(null)
     React.useLayoutEffect(() => {
+      if (context.set) {
+        context.set(null)
+      }
+      
       context.set = setElement
       setElement(context.value)
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -201,7 +201,7 @@ describe('teleporter', () => {
   })
 
   describe('multiple sources / targets', () => {
-    it('handles multiple sources', () => {
+    it('takes only the latest defined source', () => {
       const Teleporter = createTeleporter()
 
       const { getByTestId } = render(
@@ -216,7 +216,7 @@ describe('teleporter', () => {
         </div>,
       )
 
-      expect(getByTestId('target')).toHaveTextContent('AB')
+      expect(getByTestId('target')).toHaveTextContent('B')
     })
 
     it('handles uses the latest target defined', () => {


### PR DESCRIPTION
BREAKING CHANGE: If multiple sources are defined, only the deepest one in React tree will be rendered.


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->