### PR TITLE
feat: allow dispatching/bubbling events on the `Target`

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -343,8 +343,8 @@ describe("teleporter", () => {
                   Username
                 </label>
                 <input id="username" type="text" onKeyDown={onKeyDownSpy} />
-                <button type="submit" onClick={onClickSpy}>
-                  Send
+                <button type="reset" onClick={onClickSpy}>
+                  Reset
                 </button>
               </form>
             </Teleporter.Source>
@@ -354,7 +354,7 @@ describe("teleporter", () => {
 
       const label = getByText("Username");
       const input = getByRole("textbox", { name: "Username" });
-      const submitAction = getByRole("button", { name: "Send" });
+      const resetAction = getByRole("button", { name: "Reset" });
 
       fireEvent.mouseOver(label);
       expect(onMouseOverSpy).toHaveBeenCalled();
@@ -362,11 +362,10 @@ describe("teleporter", () => {
 
       fireEvent.keyDown(input, { key: "A" });
       expect(onKeyDownSpy).toHaveBeenCalled();
-      // Please, note that the example was created for fowarding only the onClick and onMouseOver
-      // evnets, eventhough the Target is "listening" keyDown events too.
+      // While the Target is listening to the onKeyDown event as well, the example teleporter only forwards the onClick and onMouseOver events.
       expect(keyDownHandlerSpy).not.toHaveBeenCalled();
 
-      fireEvent.click(submitAction);
+      fireEvent.click(resetAction);
       expect(onClickSpy).toHaveBeenCalled();
       expect(clickHandlerSpy).toHaveBeenCalled();
     });

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -294,4 +294,35 @@ describe("teleporter", () => {
       expect(getByTestId("targetB")).toHaveTextContent("A");
     });
   });
+
+  describe("events from Source", () => {
+    it("forwards click event to Target", () => {
+      const Teleporter = createTeleporter();
+      const clickSpy = jest.fn();
+      const clickHandlerSpy = jest.fn();
+
+      const { getByText } = render(
+        <div>
+          <div data-testid="target">
+            <Teleporter.Target as="header" onClick={clickHandlerSpy} />
+          </div>
+          <div>
+            <Teleporter.Source>
+              <ul>
+                <li>
+                  <a onClick={clickSpy}>Link from source</a>
+                </li>
+              </ul>
+            </Teleporter.Source>
+          </div>
+        </div>
+      );
+
+      const link = getByText("Link from source");
+      // @ts-ignore
+      fireEvent.click(link);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(clickHandlerSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -295,7 +295,26 @@ describe("teleporter", () => {
     });
   });
 
-  describe("events from Source", () => {
+  describe("Source", () => {
+    it("wraps its content in an 'unboxed' div", () => {
+      const Teleporter = createTeleporter();
+
+      const { getByText } = render(
+        <div>
+          <div data-testid="target">
+            <Teleporter.Target as="header" />
+          </div>
+          <div>
+            <Teleporter.Source>Hello</Teleporter.Source>
+          </div>
+        </div>
+      );
+
+      const sourceContent = getByText("Hello");
+      const sourceContentWrapper = sourceContent.closest("div");
+      expect(sourceContentWrapper).toHaveStyle("display: contents;");
+    });
+
     it("forwards click event to Target", () => {
       const Teleporter = createTeleporter();
       const clickSpy = jest.fn();

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -315,32 +315,59 @@ describe("teleporter", () => {
       expect(sourceContentWrapper).toHaveStyle("display: contents;");
     });
 
-    it("forwards click event to Target", () => {
-      const Teleporter = createTeleporter();
-      const clickSpy = jest.fn();
+    it("forwards given events to Target", () => {
+      const Teleporter = createTeleporter({
+        forwardToTarget: ["onClick", "onMouseOver"],
+      });
+      const onClickSpy = jest.fn();
+      const onKeyDownSpy = jest.fn();
+      const onMouseOverSpy = jest.fn();
       const clickHandlerSpy = jest.fn();
+      const mouseOverHandlerSpy = jest.fn();
+      const keyDownHandlerSpy = jest.fn();
 
-      const { getByText } = render(
+      const { getByText, getByRole } = render(
         <div>
           <div data-testid="target">
-            <Teleporter.Target as="header" onClick={clickHandlerSpy} />
+            <Teleporter.Target
+              as="header"
+              onClick={clickHandlerSpy}
+              onMouseOver={mouseOverHandlerSpy}
+              onKeyDown={keyDownHandlerSpy}
+            />
           </div>
           <div>
             <Teleporter.Source>
-              <ul>
-                <li>
-                  <a onClick={clickSpy}>Link from source</a>
-                </li>
-              </ul>
+              <form>
+                <label htmlFor="username" onMouseOver={onMouseOverSpy}>
+                  Username
+                </label>
+                <input id="username" type="text" onKeyDown={onKeyDownSpy} />
+                <button type="submit" onClick={onClickSpy}>
+                  Send
+                </button>
+              </form>
             </Teleporter.Source>
           </div>
         </div>
       );
 
-      const link = getByText("Link from source");
-      // @ts-ignore
-      fireEvent.click(link);
-      expect(clickSpy).toHaveBeenCalled();
+      const label = getByText("Username");
+      const input = getByRole("textbox", { name: "Username" });
+      const submitAction = getByRole("button", { name: "Send" });
+
+      fireEvent.mouseOver(label);
+      expect(onMouseOverSpy).toHaveBeenCalled();
+      expect(mouseOverHandlerSpy).toHaveBeenCalled();
+
+      fireEvent.keyDown(input, { key: "A" });
+      expect(onKeyDownSpy).toHaveBeenCalled();
+      // Please, note that the example was created for fowarding only the onClick and onMouseOver
+      // evnets, eventhough the Target is "listening" keyDown events too.
+      expect(keyDownHandlerSpy).not.toHaveBeenCalled();
+
+      fireEvent.click(submitAction);
+      expect(onClickSpy).toHaveBeenCalled();
       expect(clickHandlerSpy).toHaveBeenCalled();
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,8 @@ export const createTeleporter = ({
       };
     }, []);
     if (!element) return null;
-    const handleClick = (e) => element.dispatchEvent(new Event(e.type, e));
+    const handleClick = (e: React.SyntheticEvent) =>
+      element.dispatchEvent(new Event(e.type, e));
     return ReactDOM.createPortal(<div onClick={handleClick}>{children}</div>, element);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,6 +50,17 @@ export const createTeleporter = ({
 
   const useTargetRef = () => setElement;
 
+  const SourceWrapper: React.FC<React.DOMAttributes<HTMLElement>> = ({
+    children,
+    ...props
+  }) => {
+    return (
+      <div {...props} style={{ display: "contents" }}>
+        {children}
+      </div>
+    );
+  };
+
   const Target = ({ as: As = "div", ...props }: PropsWithAs<{}, "div">) => {
     return <As ref={setElement} {...props} />;
   };
@@ -85,10 +96,15 @@ export const createTeleporter = ({
         }
       };
     }, []);
+
     if (!element) return null;
     const handleClick = (e: React.SyntheticEvent) =>
       element.dispatchEvent(new Event(e.type, e));
-    return ReactDOM.createPortal(<div onClick={handleClick}>{children}</div>, element);
+
+    return ReactDOM.createPortal(
+      <SourceWrapper onClick={handleClick}>{children}</SourceWrapper>,
+      element
+    );
   };
 
   return { Source, Target, useTargetRef };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,8 @@ export const createTeleporter = ({
       };
     }, []);
     if (!element) return null;
-    return ReactDOM.createPortal(children, element);
+    const handleClick = (e) => element.dispatchEvent(new Event(e.type, e));
+    return ReactDOM.createPortal(<div onClick={handleClick}>{children}</div>, element);
   };
 
   return { Source, Target, useTargetRef };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ interface Context {
 
 export interface CreateTeleporterOptions {
   multiSources?: Boolean;
+  forwardToTarget?: string[];
 }
 
 export interface TargetRef {
@@ -38,6 +39,7 @@ export interface Teleporter {
 
 export const createTeleporter = ({
   multiSources,
+  forwardToTarget = [],
 }: CreateTeleporterOptions = {}): Teleporter => {
   const context: Context = { element: null, set: null };
 
@@ -98,11 +100,20 @@ export const createTeleporter = ({
     }, []);
 
     if (!element) return null;
-    const handleClick = (e: React.SyntheticEvent) =>
+
+    const handleEvent = (e: React.SyntheticEvent) =>
       element.dispatchEvent(new Event(e.type, e));
 
+    const eventHandlersProps: {
+      [key: string]: React.EventHandler<React.SyntheticEvent>;
+    } = {};
+
+    forwardToTarget.forEach(
+      (eventName: string) => (eventHandlersProps[eventName] = handleEvent)
+    );
+
     return ReactDOM.createPortal(
-      <SourceWrapper onClick={handleClick}>{children}</SourceWrapper>,
+      <SourceWrapper {...eventHandlersProps}>{children}</SourceWrapper>,
       element
     );
   };


### PR DESCRIPTION
## TL;DR

This PR allows making the `Target` aware of events in a teleported content.

## Problem

Despite the `Source` content being rendered within the `Target` _slot_, the last cannot intercept the events originated by that content. Although this is how the events work in a [React Portal](https://beta.reactjs.org/reference/react-dom/createPortal#reference), bubbling up through the React tree rather than the DOM tree, react-teleporter could have an option for _redirecting_ the event through the Target instead, as suggested in #7.

A simple use-case could be a sidebar closing itself when the user clicks on any of the actions held by it. Check out this [codesandbox project](https://codesandbox.io/p/sandbox/react-teleporter-bubbling-demo-x3wo4f) where it is illustrated that it does not work for teleported links (think in a contextual actions sections inside the sidebar).

## Proposed solution

This PR adds support for "forwarding" events to `Target` at the time of creating the teleporter. 

```js

const ContextualActions = createTeleporter({ forwardToTarget: ["onClick"] });

```

Do not get confused by the naming: the code actually dispatches a new event based on the intercepted one.

### Relaying on a `div` using the `display: contents;` CSS rule

To do so, an _intermediate_ `div` node has been added to wrap the `Source` children making possible to intercept and _forward_ events. Since this extra node can potentially break layouts because of the box model, the _`display: contents;`_ CSS rule is shipped through a (hopefully harmless) inline style. This rule "unboxes" the node, effectively _making it unobtrusive_. A sort of _native `<fragment>`_ (not invented yet) that will minimize (if not get rid of) undesired side effects.

Read more about it in the links you can find below, or in [this Codepen displaying how it works](https://codepen.io/dgdavid/pen/KKBGEyP).

<details>
<summary>Click to show/hide a list with few links to learn more about `display: contents;`</summary>

---

  * https://drafts.csswg.org/css-display/#valdef-display-contents
  * https://developer.mozilla.org/en-US/docs/Web/CSS/display#display_contents
  * https://caniuse.com/css-display-contents
  * https://bitsofco.de/how-display-contents-works/
  * https://css-tricks.com/get-ready-for-display-contents/

</details>

> **Acknowledgement:** I have been made aware of that rule thanks to that [comment](https://stackoverflow.com/a/69550164) in StackOverflow.

## Discarded solution

The only way I found to avoid the extra node used in the proposed solution is to _inject_ the event handler for dispatching the event on the `Target` to each child in the `Source` :exploding_head::exploding_head::exploding_head: 

However, I found it suboptimal not only because the handler had to be attached multiple times instead of only once, but also because of the required steps to achieve it:

* Use the [Children](https://beta.reactjs.org/reference/react/Children) API to iterate children, which could lead to fragile code according to the documentation.
* Check if the child [isValidElement](https://beta.reactjs.org/reference/react/isValidElement).
* Create props objects for the events to be forwarded, ensuring that an already attached handler for the same event is preserved. Otherwise, the full behavior will be broken.
* Clone the child element with the newly created props object by calling to [cloneElement](https://beta.reactjs.org/reference/react/cloneElement).

<details>
<summary>Click to show/hide a diff of a working code for that suboptimal solution on top of the code sent to this PR</summary>

---

```diff
 diff --git a/src/index.test.tsx b/src/index.test.tsx
index 80a4884..8a5a230 100644
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -296,25 +296,6 @@ describe("teleporter", () => {
   });
 
   describe("Source", () => {
-    it("wraps its content in an 'unboxed' div", () => {
-      const Teleporter = createTeleporter();
-
-      const { getByText } = render(
-        <div>
-          <div data-testid="target">
-            <Teleporter.Target as="header" />
-          </div>
-          <div>
-            <Teleporter.Source>Hello</Teleporter.Source>
-          </div>
-        </div>
-      );
-
-      const sourceContent = getByText("Hello");
-      const sourceContentWrapper = sourceContent.closest("div");
-      expect(sourceContentWrapper).toHaveStyle("display: contents;");
-    });
-
     it("forwards given events to Target", () => {
       const Teleporter = createTeleporter({
         forwardToTarget: ["onClick", "onMouseOver"],
diff --git a/src/index.tsx b/src/index.tsx
index 2c72a45..6965148 100644
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,17 +52,6 @@ export const createTeleporter = ({
 
   const useTargetRef = () => setElement;
 
-  const SourceWrapper: React.FC<React.DOMAttributes<HTMLElement>> = ({
-    children,
-    ...props
-  }) => {
-    return (
-      <div {...props} style={{ display: "contents" }}>
-        {children}
-      </div>
-    );
-  };
-
   const Target = ({ as: As = "div", ...props }: PropsWithAs<{}, "div">) => {
     return <As ref={setElement} {...props} />;
   };
@@ -104,16 +93,28 @@ export const createTeleporter = ({
     const handleEvent = (e: React.SyntheticEvent) =>
       element.dispatchEvent(new Event(e.type, e));
 
-    const eventHandlersProps: {
-      [key: string]: React.EventHandler<React.SyntheticEvent>;
-    } = {};
+    const newChildren = React.Children.map(children, child => {
+      if (!React.isValidElement(child)) return child;
 
-    forwardToTarget.forEach(
-      (eventName: string) => (eventHandlersProps[eventName] = handleEvent)
-    );
+      const childProps = child.props || {};
+      const newChildProps : { [key: string]: React.EventHandler<React.SyntheticEvent> } = {};
+
+      forwardToTarget.forEach((eventName: string) => {
+        if (childProps[eventName]) {
+          newChildProps[eventName] = (e) => {
+            childProps[eventName](e);
+            handleEvent(e)
+          }
+        } else {
+          newChildProps[eventName] = handleEvent;
+        }
+      });
+
+      return React.cloneElement(child, newChildProps);
+    })
 
     return ReactDOM.createPortal(
-      <SourceWrapper {...eventHandlersProps}>{children}</SourceWrapper>,
+      newChildren,
       element
     );
   };
```
</details>


## Open questions

Regarding the proposed changes, I still have some doubts

* Should that intermediate node be always there, as it is, or would it be better to only wrap Source children when there is any event to be forwarded?

* Should the code be adapted to stop the propagation of the original event once it has been "forwarded" to the Target? If so, should it be configurable or simply a consequence of forwarding the events?

## Pending tasks

- [ ] Update the README

  This is not done on purpose for:

    * postponing it to the very end, once the PR is in its final state after reviews and suggestions.

    * asking help to do so.

- [x] Update testing-library to the latest version and use `user-event`. 

     See https://testing-library.com/docs/user-event/intro#differences-from-fireevent

     ~~**Postponed for a follow-up PR.**~~ See https://github.com/gregberge/react-teleporter/pull/48

---

A big thank you to @backpackerhh for the _rubber duck debugging_ session :wink:
  