### PR TITLE
feat: support function as Source children

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ const Teleporter = createTeleporter({ multiSources: true })
 // The target will contains the two links
 ```
 
+### Use function as children
+
+Useful for having access to the `Target` element. E.g., to dispatch an event through the `Target` when something happens in the `Source`.
+
+```js
+const forwardEvent = element => event => element.dispatch(new Event(event.type, event));
+
+<Source>
+  {element => <div onClick={forwardEvent(element)}></div>}
+</Source>
+```
+
 ## API
 
 ### createTeleporter

--- a/README.md
+++ b/README.md
@@ -114,11 +114,14 @@ const Teleporter = createTeleporter({ multiSources: true })
 Useful for having access to the `Target` element. E.g., to dispatch an event through the `Target` when something happens in the `Source`.
 
 ```js
-const forwardEvent = element => event => element.dispatch(new Event(event.type, event));
+const Teleporter = createTeleporter();
 
-<Source>
-  {element => <div onClick={forwardEvent(element)}></div>}
-</Source>
+const forwardEvent = (element) => (event) =>
+  element.dispatch(new Event(event.type, event));
+
+<Teleporter.Source>
+  {(element) => <div onClick={forwardEvent(element)}></div>}
+</Teleporter.Source>;
 ```
 
 ## API

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -69,6 +69,24 @@ describe("teleporter", () => {
     expect(getByTestId("target").firstChild.tagName).toBe("HEADER");
   });
 
+  it("supports function as children on source", () => {
+    const Teleporter = createTeleporter();
+    const sourceContent = (target: Element): React.ReactNode => (
+      <p>Hello from {target.id}!</p>
+    );
+
+    const { getByRole } = render(
+      <div>
+        <Teleporter.Target as="header" id="Target Element" />
+        <div>
+          <Teleporter.Source>{sourceContent}</Teleporter.Source>
+        </div>
+      </div>
+    );
+
+    expect(getByRole("banner")).toHaveTextContent("Hello from Target Element!");
+  });
+
   it("forwards props to Target", () => {
     const Teleporter = createTeleporter();
     const clickSpy = jest.fn();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,8 @@ interface Context {
   set: TargetRefRef | null;
 }
 
+type ChildrenFunction = (target: Element) => React.ReactNode;
+
 export interface CreateTeleporterOptions {
   multiSources?: Boolean;
 }
@@ -31,7 +33,7 @@ export interface TargetRef {
 }
 
 export interface Teleporter {
-  Source: React.FC<{ children: React.ReactNode }>;
+  Source: React.FC<{ children: React.ReactNode | ChildrenFunction }>;
   Target: ComponentWithAs<{}, "div">;
   useTargetRef: () => TargetRef;
 }
@@ -54,7 +56,11 @@ export const createTeleporter = ({
     return <As ref={setElement} {...props} />;
   };
 
-  const Source = ({ children }: { children: React.ReactNode }) => {
+  const Source = ({
+    children,
+  }: {
+    children: React.ReactNode | ChildrenFunction;
+  }) => {
     const [element, setElement] = React.useState<Element | null>(null);
 
     React.useLayoutEffect(() => {
@@ -86,7 +92,9 @@ export const createTeleporter = ({
       };
     }, []);
     if (!element) return null;
-    return ReactDOM.createPortal(children, element);
+    const content =
+      typeof children === "function" ? children(element) : children;
+    return ReactDOM.createPortal(content, element);
   };
 
   return { Source, Target, useTargetRef };


### PR DESCRIPTION
Related to https://github.com/gregberge/react-teleporter/pull/47, add supports for function as children on `Source`. That function will receive the `Target` element as argument for allowing complex use case as the described in the linked PR:

> A sidebar closing itself when the user clicks on any of the actions held by it. Check out this [codesandbox project](https://codesandbox.io/p/sandbox/react-teleporter-bubbling-demo-x3wo4f)


Based on @gregberge's comment at https://github.com/gregberge/react-teleporter/pull/47#issuecomment-1420306002

